### PR TITLE
Localization files are not included in archive when you run "setup.py build"

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,5 +2,6 @@ include LICENSE.txt
 include README.rst
 include MANIFEST.in
 recursive-include cicu *.py *.txt *.rst *.js *.css
+recursive-include cicu/locale *.po *.mo
 recursive-include cicu/static *.py *.txt *.js *.css
 recursive-include cicu/migrations *.py *.txt *.js *.css

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,4 @@ recursive-include cicu *.py *.txt *.rst *.js *.css
 recursive-include cicu/locale *.po *.mo
 recursive-include cicu/static *.py *.txt *.js *.css
 recursive-include cicu/migrations *.py *.txt *.js *.css
+

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(name = "clean-image-crop-uploader",
     author_email = "alfredo.saglimbeni@gmail.com",
     url = "",
     packages = find_packages(),
-    include_package_data=False,
+    include_package_data=True,
     install_requires = [
         'PIL==1.1.7','django>=1.4.3','south>=0.7.6'
         ],


### PR DESCRIPTION
I had to manually install localization files, after a bit of searches, I found other projects on github that add:
- "project_name/locale *.po *.mo" to MANIFEST.in
- "include_package_data=True" to setup.py
