### PR TITLE
no default any more

### DIFF
--- a/cicu/urls.py
+++ b/cicu/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 
 urlpatterns = patterns('cicu.views',


### PR DESCRIPTION
django.conf.urls.default is deprecated
