### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,9 +2,9 @@ clean-image-crop-uploader (CICU)
 ================================
 .. image:: https://d2weczhvl823v0.cloudfront.net/asaglimbeni/django-datetime-widget/trend.png
     :target: https://bitdeli.com/free
-.. image:: https://pypip.in/v/clean-image-crop-uploader/badge.png
+.. image:: https://img.shields.io/pypi/v/clean-image-crop-uploader.svg
     :target: https://crate.io/packages/clean-image-crop-uploader
-.. image:: https://pypip.in/d/clean-image-crop-uploader/badge.png
+.. image:: https://img.shields.io/pypi/dm/clean-image-crop-uploader.svg
     :target: https://crate.io/packages/clean-image-crop-uploader
     
 ``clean-image-crop-uploader`` is a django widget to upload an image via Ajax and crop it using `Jcrop


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20clean-image-crop-uploader))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `clean-image-crop-uploader`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.